### PR TITLE
docs: replace npm add with npm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This is a Typescript client for the [Unstructured API](https://unstructured-io.g
 ### NPM
 
 ```bash
-npm add unstructured-client
+npm install unstructured-client
 ```
 
 ### Yarn


### PR DESCRIPTION
## Description
Although npm add is an alias to npm install, since NPM 5, it's become a common convention to use npm install instead of npm add since the --save option is no more.

replaces:
```
npm add unstructured-client 
```
with:
```
npm install unstructured-client
```

closes https://github.com/Unstructured-IO/unstructured-js-client/issues/1
