### PR TITLE
Temporarily disable the publish job

### DIFF
--- a/.github/workflows/speakeasy_sdk_publish.yaml
+++ b/.github/workflows/speakeasy_sdk_publish.yaml
@@ -9,8 +9,8 @@ jobs:
   publish:
     uses: speakeasy-api/sdk-generation-action/.github/workflows/sdk-publish.yaml@v14
     with:
-      create_release: true
-      publish_typescript: true
+      create_release: false
+      publish_typescript: false
     secrets:
       github_access_token: ${{ secrets.GITHUB_TOKEN }}
       speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}


### PR DESCRIPTION
Let's prep the v2 client in the repo before publishing a new version.