### PR TITLE
Fix issue with accessing metadata property of returned elements inside integration tests

### DIFF
--- a/test/integration/SplitPdfHook.test.ts
+++ b/test/integration/SplitPdfHook.test.ts
@@ -195,14 +195,14 @@ describe("SplitPdfHook integration tests check splitted file is same as not spli
       const splitElements = respSplit.elements?.map((el) => ({
         ...el,
         metadata: {
-          ...el.metadata,
+          ...el['metadata'],
           parent_id: undefined,
         },
       }));
       const singleElements = respSingle.elements?.map((el) => ({
         ...el,
         metadata: {
-          ...el.metadata,
+          ...el['metadata'],
           parent_id: undefined,
         },
       }));


### PR DESCRIPTION
Tests might fail because of wrong openapi spec but they should not throw metadata field access error