### PR TITLE
chore: bump js-client to 0.11.3

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -1,12 +1,12 @@
 lockVersion: 2.0.0
 id: f42cb8e6-e2ce-4565-b975-5a9f38b94d5a
 management:
-  docChecksum: fd76ef24456d50f23903277067ffaa2e
-  docVersion: 1.0.35
+  docChecksum: c209069202bc537f70476e86044130a0
+  docVersion: 1.0.39
   speakeasyVersion: 1.308.1
   generationVersion: 2.342.6
-  releaseVersion: 0.11.2
-  configChecksum: f5f0ec91134be577b27ca7ca87e4f5fa
+  releaseVersion: 0.11.3
+  configChecksum: 9eaa07233a4c948e9f569fd1a387ceb8
   repoURL: https://github.com/Unstructured-IO/unstructured-js-client.git
   repoSubDirectory: .
   installationURL: https://github.com/Unstructured-IO/unstructured-js-client

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -344,3 +344,13 @@ Based on:
 - [typescript v0.11.1] .
 ### Releases
 - [NPM v0.11.2] https://www.npmjs.com/package/unstructured-client/v/0.11.2 - .
+
+## 2024-07-01 10:00:00
+### Changes
+Based on:
+- OpenAPI Doc  
+- Speakeasy CLI 1.308.1 (2.342.6) https://github.com/speakeasy-api/speakeasy
+### Generated
+- [typescript v0.11.3] .
+### Releases
+- [NPM v0.11.3] https://www.npmjs.com/package/unstructured-client/v/0.11.3 - .

--- a/gen.yaml
+++ b/gen.yaml
@@ -10,7 +10,7 @@ generation:
   auth:
     oAuth2ClientCredentialsEnabled: false
 typescript:
-  version: 0.11.2
+  version: 0.11.3
   additionalDependencies:
     dependencies:
       async: ^3.2.5

--- a/jsr.json
+++ b/jsr.json
@@ -2,7 +2,7 @@
 
 {
   "name": "unstructured-client",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "exports": {
     ".": "./src/index.ts",    
     "./sdk/models/errors": "./src/sdk/models/errors/index.ts",    

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unstructured-client",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "author": "Unstructured",  
   "main": "./index.js",
   "sideEffects": false,

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -60,8 +60,8 @@ export function serverURLFromOptions(options: SDKOptions): URL | null {
 
 export const SDK_METADATA = {
     language: "typescript",
-    openapiDocVersion: "1.0.35",
-    sdkVersion: "0.11.2",
+    openapiDocVersion: "1.0.39",
+    sdkVersion: "0.11.3",
     genVersion: "2.342.6",
-    userAgent: "speakeasy-sdk/typescript 0.11.2 2.342.6 1.0.35 unstructured-client",
+    userAgent: "speakeasy-sdk/typescript 0.11.3 2.342.6 1.0.39 unstructured-client",
 } as const;


### PR DESCRIPTION
Bump the version and regenerate locally in order to release the concurrency change in #87. If we trigger the github regeneration, as per #86, the tests are failing. While we fix that up, let's get the other change unblocked.