### PR TITLE
fix: 404 response if the server url includes /general/v0/general

### DIFF
--- a/src/hooks/custom/HttpsCheckHook.ts
+++ b/src/hooks/custom/HttpsCheckHook.ts
@@ -15,14 +15,15 @@ export class HttpsCheckHook implements SDKInitHook {
   sdkInit(opts: SDKInitOptions): SDKInitOptions {
     const { baseURL, client } = opts;
 
-    if (
-      baseURL &&
-      BASE_HOSTNAME_REGEX.test(baseURL.hostname) &&
-      baseURL.protocol !== BASE_PROTOCOL
-    ) {
-      console.warn("Base URL protocol is not HTTPS. Updating to HTTPS.");
-      const newBaseURL = baseURL.href.replace(baseURL.protocol, BASE_PROTOCOL);
-      return { baseURL: new URL(newBaseURL), client: client };
+    if (baseURL) {
+      // -- pathname should always be empty
+      baseURL.pathname = "/";
+
+      if (BASE_HOSTNAME_REGEX.test(baseURL.hostname) && baseURL.protocol !== BASE_PROTOCOL) {
+        console.warn("Base URL protocol is not HTTPS. Updating to HTTPS.");
+        const newBaseURL = baseURL.href.replace(baseURL.protocol, BASE_PROTOCOL);
+        return {baseURL: new URL(newBaseURL), client: client};
+      }
     }
 
     return { baseURL: baseURL, client: client };

--- a/test/integration/HttpsCheckHook.test.ts
+++ b/test/integration/HttpsCheckHook.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from "fs";
+
+import { UnstructuredClient } from "../../src";
+import { PartitionResponse } from "../../src/sdk/models/operations";
+import { PartitionParameters, Strategy } from "../../src/sdk/models/shared";
+
+describe("HttpsCheckHook integration tests", () => {
+    const FAKE_API_KEY = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+    it.each([
+        "http://localhost:8000",
+        "http://localhost:8000/general/v0/general",
+    ])("should throw error when given filename is empty", async (serverURL) => {
+        const client = new UnstructuredClient({
+            serverURL: serverURL,
+            security: {
+                apiKeyAuth: FAKE_API_KEY,
+            },
+        });
+
+        const file = {
+            content: readFileSync("test/data/layout-parser-paper-fast.pdf"),
+            fileName: "test/data/layout-parser-paper-fast.pdf",
+        };
+
+        const requestParams: PartitionParameters = {
+            files: file,
+            strategy: Strategy.Fast,
+        };
+
+        const res: PartitionResponse = await client.general.partition({
+            partitionParameters: {
+                ...requestParams,
+                splitPdfPage: false,
+            },
+        });
+
+        expect(res.statusCode).toEqual(200);
+    });
+});

--- a/test/unit/HttpsCheckHook.test.ts
+++ b/test/unit/HttpsCheckHook.test.ts
@@ -61,4 +61,16 @@ describe("HttpsCheckHook", () => {
     expect(result.baseURL).toBeNull();
     expect(consoleSpy).not.toHaveBeenCalled();
   });
+
+  it("should update the pathname to empty", () => {
+    const baseURL = new URL("https://example.unstructuredapp.io/general/v0/general");
+    const client = new HTTPClient();
+    const opts = { baseURL, client };
+    const hook = new HttpsCheckHook();
+
+    const result = hook.sdkInit(opts);
+
+    expect(result.baseURL?.pathname).toBe("/");
+    expect(consoleSpy).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
This PR aims to fix a bug that causes a 404 response if the server URL includes `/general/v0/general`.