### PR TITLE
chore: bump js client minor version

### DIFF
--- a/gen.yaml
+++ b/gen.yaml
@@ -10,7 +10,7 @@ generation:
   auth:
     oAuth2ClientCredentialsEnabled: false
 typescript:
-  version: 0.13.0
+  version: 0.14.0
   additionalDependencies:
     dependencies:
       async: ^3.2.5


### PR DESCRIPTION
In anticipation of the default server url changing. The next autogenerated pr will set this version in the package.