### PR TITLE
doc [RUDOLPH-288] Add serverless signup to js SDK readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <p>Typescript SDK for the Unstructured API</p>
 </h2>
 
-This is a Typescript client for the [Unstructured API](https://docs.unstructured.io/api-reference/api-services/overview). 
+This is a Typescript client for the [Unstructured API](https://docs.unstructured.io/api-reference/api-services/saas-api-development-guide) and you can sign up for your own API URL and API key on https://app.unstructured.io. 
 
 Please refer to the [Unstructured docs](https://docs.unstructured.io/api-reference/api-services/sdk-jsts) for a full guide to using the client.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <p>Typescript SDK for the Unstructured API</p>
 </h2>
 
-This is a Typescript client for the [Unstructured API](https://docs.unstructured.io/api-reference/api-services/saas-api-development-guide) and you can sign up for your own API URL and API key on https://app.unstructured.io. 
+This is a Typescript client for the [Unstructured API](https://docs.unstructured.io/api-reference/api-services/saas-api-development-guide) and you can sign up for your API key on https://app.unstructured.io. 
 
 Please refer to the [Unstructured docs](https://docs.unstructured.io/api-reference/api-services/sdk-jsts) for a full guide to using the client.
 


### PR DESCRIPTION
### Summary

update readme so that it points to serverless as default url and add the api key sign up url