### PR TITLE
increase timeout to 60 minutes

### DIFF
--- a/src/hooks/custom/SplitPdfHook.ts
+++ b/src/hooks/custom/SplitPdfHook.ts
@@ -164,6 +164,10 @@ export class SplitPdfHook
         splitSize,
     )
 
+    const oneSecond = 1000;
+    const oneMinute = 1000 * 60;
+    const sixtyMinutes = oneMinute * 60;
+
     const headers = prepareRequestHeaders(request);
 
     const requests: Request[] = [];
@@ -185,11 +189,10 @@ export class SplitPdfHook
         file.name,
         firstPageNumber
       );
-      const timeoutInMs = 60 * 10 * 1000;
       const req = new Request(requestClone, {
         headers,
         body,
-        signal: AbortSignal.timeout(timeoutInMs)
+        signal: AbortSignal.timeout(sixtyMinutes)
       });
       requests.push(req);
       setIndex+=1;
@@ -203,15 +206,14 @@ export class SplitPdfHook
     // These are the retry values from our api spec
     // We need to hardcode them here until we're able to reuse the SDK
     // from within this hook
-    const oneSecond = 1000;
-    const oneMinute = 1000 * 60;
+
     const retryConfig = {
         strategy: "backoff",
         backoff: {
             initialInterval: oneSecond * 3,
             maxInterval: oneMinute * 12,
             exponent: 1.88,
-            maxElapsedTime: oneMinute * 30,
+            maxElapsedTime: sixtyMinutes,
         },
     } as RetryConfig;
 
@@ -223,7 +225,7 @@ export class SplitPdfHook
         try {
          const response = await retry(
               async () => {
-                return await this.client!.request(req.clone());
+                return await this.client!.request(req);
               },
               { config: retryConfig, statusCodes: retryCodes }
           );

--- a/src/hooks/custom/common.ts
+++ b/src/hooks/custom/common.ts
@@ -32,7 +32,8 @@ export class HTTPClientExtension extends HTTPClient {
   }
 
   override async request(request: Request): Promise<Response> {
-    if (request.url === "https://no-op/") {
+    const clone = request.clone();
+    if (clone.url === "https://no-op/") {
       return new Response('{}', {
         headers: [
             ["fake-response", "fake-response"]
@@ -41,6 +42,6 @@ export class HTTPClientExtension extends HTTPClient {
         statusText: 'OK_NO_OP'
       });
     }
-    return super.request(request);
+    return super.request(clone);
    }
 }


### PR DESCRIPTION
A customer reported that large PDFs are still failing, even after the updated retry logic for the occasional 502/503s.  The job client previously had an incorrect limit of 10 minutes for maximum execution time.  This change increase the total client execution time to 60 minutes.

### Testing
Ran custom integration tests with 2500 page PDFs running with the following settings:

```
const requestParams: PartitionParameters = {
            files: file,
            splitPdfPage: true,
            strategy: Strategy.HiRes,
            splitPdfAllowFailed: false,
            splitPdfConcurrencyLevel: 15
        };

        const res: PartitionResponse = await client.general.partition({
            partitionParameters: {
                ...requestParams
            },
        });
```