### PR TITLE
fix: Use crypto.randomUUID to fix dependency error

### DIFF
--- a/gen.yaml
+++ b/gen.yaml
@@ -15,7 +15,6 @@ typescript:
     dependencies:
       async: ^3.2.5
       pdf-lib: ^1.17.1
-      uuid: ^10.0.0
     devDependencies:
       '@types/async': ^3.2.24
       '@types/jest': ^29.5.12

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   "devDependencies": {
     "@types/async": "^3.2.24",
     "@types/jest": "^29.5.12",
-    "@types/uuid": "^10.0.0",
     "@typescript-eslint/eslint-plugin": "^7.7.1",
     "@typescript-eslint/parser": "^7.7.1",
     "eslint": "^8.57.0",
@@ -33,7 +32,6 @@
   },
   "dependencies": {
     "async": "^3.2.5",
-    "pdf-lib": "^1.17.1",
-    "uuid": "^10.0.0"
+    "pdf-lib": "^1.17.1"
   }
 }

--- a/src/hooks/custom/SplitPdfHook.ts
+++ b/src/hooks/custom/SplitPdfHook.ts
@@ -1,5 +1,5 @@
 import async from "async";
-import { v4 as uuidv4 } from 'uuid';
+import 'crypto';
 
 import {
   AfterErrorContext,
@@ -99,7 +99,7 @@ export class SplitPdfHook
   ): Promise<Request> {
 
     // setting the current operationID to be unique
-    const operationID = "partition-" + uuidv4();
+    const operationID = "partition-" + crypto.randomUUID();
     hookCtx.operationID = operationID;
 
     const requestClone = request.clone();

--- a/src/hooks/custom/SplitPdfHook.ts
+++ b/src/hooks/custom/SplitPdfHook.ts
@@ -1,5 +1,5 @@
 import async from "async";
-import 'crypto';
+import {randomUUID} from 'crypto';
 
 import {
   AfterErrorContext,
@@ -99,7 +99,7 @@ export class SplitPdfHook
   ): Promise<Request> {
 
     // setting the current operationID to be unique
-    const operationID = "partition-" + crypto.randomUUID();
+    const operationID = "partition-" + randomUUID();
     hookCtx.operationID = operationID;
 
     const requestClone = request.clone();


### PR DESCRIPTION
The generate job [here](https://github.com/Unstructured-IO/unstructured-js-client/actions/runs/11182023581) is complaining that we need to install type hints for uuid. Instead, we can switch to crypto.randomUUID and avoid an extra dependency.