### PR TITLE
chore: Update signup and docs links at the top of the readme

### DIFF
--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -3,7 +3,7 @@ speakeasyVersion: latest
 sources:
     my-source:
         inputs:
-            - location: https://api.unstructured.io/general/openapi.json
+            - location: https://api.unstructuredapp.io/general/openapi.json
         overlays:
             - location: ./overlay_client.yaml
         registry:

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PACKAGE_NAME := unstructured-js-client
 CURRENT_DIR := $(shell pwd)
 ARCH := $(shell uname -m)
 DOCKER_IMAGE ?= quay.io/unstructured-io/unstructured-api:latest
-OPENAPI_DOCS_URL ?= https://api.unstructured.io/general/openapi.json
+OPENAPI_DOCS_URL ?= https://api.unstructuredapp.io/general/openapi.json
 
 ###########
 # Install #

--- a/README.md
+++ b/README.md
@@ -10,12 +10,13 @@
 </div>
 
 <h2 align="center">
-  <p>Typescript SDK for the Unstructured API</p>
+  <p>TypeScript SDK for the Unstructured API</p>
 </h2>
 
-This is a Typescript client for the [Unstructured API](https://docs.unstructured.io/api-reference/api-services/saas-api-development-guide) and you can sign up for your API key on https://app.unstructured.io. 
+This is a HTTP client for the [Unstructured Platform API](https://docs.unstructured.io/platform-api/overview). You can sign up [here](https://unstructured.io/developers) and process 1000 free pages per day for 14 days.
 
-Please refer to the [Unstructured docs](https://docs.unstructured.io/api-reference/api-services/sdk-jsts) for a full guide to using the client.
+Please refer to the our documentation for a full guide on integrating the [Partition Endpoint](https://docs.unstructured.io/platform-api/partition-api/sdk-jsts) into your JavaScript/TypeScript code. Support for the [Workflow Endpoint](https://docs.unstructured.io/platform-api/api/overview) is coming soon. 
+
 
 ## SDK Installation
 


### PR DESCRIPTION
Note that the platform workflow functionality is coming soon.

Also, swap out the URL for pulling the partitioning endpoint spec.