### PR TITLE
Fix: Correct typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ The `HTTPClient` constructor takes an optional `fetcher` argument that can be
 used to integrate a third-party HTTP client or when writing tests to mock out
 the HTTP client and feed in fixtures.
 
-The following example shows how to use the `"beforeRequest"` hook to to add a
+The following example shows how to use the `"beforeRequest"` hook to add a
 custom header and a timeout to requests and how to use the `"requestError"` hook
 to log errors:
 


### PR DESCRIPTION
Hey, our tool caught a few typos in your repository.

Also, a few typos on your site like 'scaleability'. Here is your error report:
 https://triplechecker.com/s/KhnZEJ/unstructured.io

Hope it's helpful!
