### PR TITLE
Add package license metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "unstructured-client",
   "version": "0.32.0",
   "author": "Unstructured",
+  "license": "MIT",
   "type": "module",
   "bin": {
     "mcp": "bin/mcp-server.js"


### PR DESCRIPTION
## Summary

- add MIT license metadata to the package manifest
- align npm metadata with the repository license

## Verification

- `npm view unstructured-client@latest name version license repository homepage bugs --json`
- `node -e "const p=require('./package.json'); if (p.license !== 'MIT') throw new Error('license mismatch'); console.log(p.name, p.version, p.license)"`
- `git diff --check`
- `npm pack --dry-run --ignore-scripts --json`
